### PR TITLE
Fix putchar() / getchar() prototypes

### DIFF
--- a/firmware/api/uart.c
+++ b/firmware/api/uart.c
@@ -28,13 +28,26 @@
 #include "ioport.h"
 #include "uart.h"
 
-void putchar(int8_t cin)
+#if defined(__SDCC) && __SDCC_REVISION < 9624
+void putchar(char c)
 {
     while ((in(uart_lsr) & (1 << 6)) == 0);
-    out(uart_thr, cin);
+    out(uart_thr, c);
 }
+#else
+int putchar(int c)
+{
+    while ((in(uart_lsr) & (1 << 6)) == 0);
+    out(uart_thr, c);
+    return c;
+}
+#endif
 
-int8_t getchar()
+#if defined(__SDCC) && __SDCC_REVISION < 9989
+char getchar()
+#else
+int getchar()
+#endif
 {
     while ((in(uart_lsr) & (1 << 0)) == 0);
     return in(uart_rbr);

--- a/firmware/api/uart.h
+++ b/firmware/api/uart.h
@@ -28,8 +28,19 @@
 
 #include <stdint.h>
 
-void putchar(int8_t cin);
-int8_t getchar();
+#if defined(__SDCC) && __SDCC_REVISION < 9624
+void putchar(char c);
+#else
+int putchar(int c);
+#endif
+
+#if defined(__SDCC) && __SDCC_REVISION < 9989
+char getchar(void);
+#else
+int getchar(void);
+#endif
+
 void Initialize_16450(uint16_t baud);
 
 #endif
+


### PR DESCRIPTION
In old SDCC versions, putchar() and getchar() prototypes were not standard-compliant. iceZ0mb1e stil used the old prototypes, and thus does not compile with current SDCC.

The simplest fix would be to just use the standard prototypes and require a current SDCC.

This fix is a bit more complex, but allows compilation of iceZ0mb1e with both older and current SDCC.

Philipp
