### PR TITLE
add support for eis and riegel boards

### DIFF
--- a/makefile
+++ b/makefile
@@ -72,6 +72,16 @@ else ifeq ($(TARGET),8k)
 	PNRFLAGS = --hx8k --package ct256
 	ICETIMEFLAGS = -d hx8k
 	FPGA_PINMAP = ./pinmap/hx8k.pcf
+else ifeq ($(TARGET),eis)
+	SRC += ./top/eis.v
+	PNRFLAGS = --hx8k --package bg121
+	ICETIMEFLAGS = -d hx8k
+	FPGA_PINMAP = ./pinmap/eis.pcf
+else ifeq ($(TARGET),riegel)
+	SRC += ./top/riegel.v
+	PNRFLAGS = --hx8k --package bg121
+	ICETIMEFLAGS = -d hx8k
+	FPGA_PINMAP = ./pinmap/riegel.pcf
 else ifeq ($(TARGET),tinybx)
 	SRC += ./top/tinybx.v
 	PNRFLAGS = --hx8k --package cm81

--- a/pinmap/eis.pcf
+++ b/pinmap/eis.pcf
@@ -1,0 +1,12 @@
+set_io clk L5
+
+set_io spi_cs K10
+set_io spi_sclk L10
+set_io spi_mosi K9
+set_io spi_miso J9
+
+set_io i2c_scl L3
+set_io i2c_sda K5
+
+set_io uart_rxd K3
+set_io uart_txd L1

--- a/pinmap/riegel.pcf
+++ b/pinmap/riegel.pcf
@@ -1,0 +1,23 @@
+set_io clk L5
+
+# PMODA (side)
+set_io D1 J5
+set_io D2 L1
+set_io D3 J3
+set_io D4 G3
+set_io D5 L2
+set_io D6 K5
+set_io D7 H3
+set_io D8 H7
+
+set_io spi_cs K10
+set_io spi_sclk L10
+set_io spi_mosi K9
+set_io spi_miso J9
+
+# PMODB (front)
+set_io uart_rxd H2
+set_io uart_txd J2
+
+set_io i2c_scl K1
+set_io i2c_sda J1

--- a/top/eis.v
+++ b/top/eis.v
@@ -1,0 +1,86 @@
+//
+// iceZ0mb1e - FPGA 8-Bit TV80 SoC for Lattice iCE40
+// with complete open-source toolchain flow using yosys and SDCC
+//
+// Copyright (c) 2018 Franz Neumann (netinside2000@gmx.de)
+// Copyright (c) 2023 Lone Dynamics Corporation (info@lonedynamics.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included 
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+module top(
+	input clk,
+	output uart_txd,
+	input uart_rxd,
+	output i2c_scl,
+	inout i2c_sda,
+    output spi_sclk,
+	output spi_mosi,
+	input  spi_miso,
+    output spi_cs
+);
+
+	wire[7:0] P1_out;
+	wire[7:0] P2_out;
+
+	wire i2c_scl;
+	wire i2c_sda_out;
+	wire i2c_sda_in;
+	wire i2c_sda_oen;
+
+	SB_IO #(
+		.PIN_TYPE(6'b 1010_01),
+		.PULLUP(1'b 0)
+	) i2c_sda_pin (
+		.PACKAGE_PIN(i2c_sda),
+		.OUTPUT_ENABLE(i2c_sda_oen),
+		.D_OUT_0(i2c_sda_out),
+		.D_IN_0(i2c_sda_in)
+	);
+
+	reg [1:0] clkdiv;
+
+	always @(posedge clk) begin
+		clkdiv <= clkdiv + 1;
+	end
+
+	wire clk12 = clkdiv[1];
+
+	iceZ0mb1e core (
+		.clk		(clk12),
+		.uart_txd	(uart_txd),
+		.uart_rxd	(uart_rxd),
+		.i2c_scl	(i2c_scl),
+		.i2c_sda_in	(i2c_sda_in),
+		.i2c_sda_out	(i2c_sda_out),
+		.i2c_sda_oen	(i2c_sda_oen),
+    	.spi_sclk	(spi_sclk),
+		.spi_mosi	(spi_mosi),
+		.spi_miso	(spi_miso),
+    	.spi_cs		(spi_cs),
+		.P1_out		(P1_out),
+		.P1_in		(8'h55),
+		.P1_oen		(),
+		.P2_out		(P2_out),
+		.P2_in		(8'hAA),
+		.P2_oen		(),
+		.debug		()
+	);
+
+endmodule

--- a/top/riegel.v
+++ b/top/riegel.v
@@ -1,0 +1,103 @@
+//
+// iceZ0mb1e - FPGA 8-Bit TV80 SoC for Lattice iCE40
+// with complete open-source toolchain flow using yosys and SDCC
+//
+// Copyright (c) 2018 Franz Neumann (netinside2000@gmx.de)
+// Copyright (c) 2023 Lone Dynamics Corporation (info@lonedynamics.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included 
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+module top(
+	input clk,
+   output D1,
+   output D2,
+   output D3,
+   output D4,
+   output D5,
+   output D6,
+   output D7,
+   output D8,
+	output uart_txd,
+	input uart_rxd,
+	output i2c_scl,
+	inout i2c_sda,
+    output spi_sclk,
+	output spi_mosi,
+	input  spi_miso,
+    output spi_cs
+);
+
+	wire[7:0] P1_out;
+	wire[7:0] P2_out;
+
+	wire i2c_scl;
+	wire i2c_sda_out;
+	wire i2c_sda_in;
+	wire i2c_sda_oen;
+
+   assign D1 = P1_out[0];
+   assign D2 = P1_out[1];
+   assign D3 = P1_out[2];
+   assign D4 = P1_out[3];
+   assign D5 = P1_out[4];
+   assign D6 = P1_out[5];
+   assign D7 = P1_out[6];
+   assign D8 = P1_out[7];
+
+	SB_IO #(
+		.PIN_TYPE(6'b 1010_01),
+		.PULLUP(1'b 0)
+	) i2c_sda_pin (
+		.PACKAGE_PIN(i2c_sda),
+		.OUTPUT_ENABLE(i2c_sda_oen),
+		.D_OUT_0(i2c_sda_out),
+		.D_IN_0(i2c_sda_in)
+	);
+
+	reg [1:0] clkdiv;
+
+	always @(posedge clk) begin
+		clkdiv <= clkdiv + 1;
+	end
+
+	wire clk12 = clkdiv[1];
+
+	iceZ0mb1e core (
+		.clk		(clk12),
+		.uart_txd	(uart_txd),
+		.uart_rxd	(uart_rxd),
+		.i2c_scl	(i2c_scl),
+		.i2c_sda_in	(i2c_sda_in),
+		.i2c_sda_out	(i2c_sda_out),
+		.i2c_sda_oen	(i2c_sda_oen),
+    	.spi_sclk	(spi_sclk),
+		.spi_mosi	(spi_mosi),
+		.spi_miso	(spi_miso),
+    	.spi_cs		(spi_cs),
+		.P1_out		(P1_out),
+		.P1_in		(8'h55),
+		.P1_oen		(),
+		.P2_out		(P2_out),
+		.P2_in		(8'hAA),
+		.P2_oen		(),
+		.debug		()
+	);
+
+endmodule


### PR DESCRIPTION
This PR adds support for the Eis and Riegel FPGA computers.

https://github.com/machdyne/eis
https://github.com/machdyne/riegel